### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout repo


### PR DESCRIPTION
Potential fix for [https://github.com/fortytwoservices/checkid-public-docs/security/code-scanning/1](https://github.com/fortytwoservices/checkid-public-docs/security/code-scanning/1)

To fix the problem, explicitly set the permissions for the `deploy` job to the minimum required. In this case, since the job pushes changes to the repository (to the `gh-pages` branch when deploying documentation), it needs write permissions for repository contents. Add a `permissions:` block to the `deploy` job (after line 10), specifying `contents: write`. This will limit the GitHub Actions token's permissions, adhering to the principle of least privilege.

No new imports, methods, or definitions are needed—this is a YAML configuration change within `.github/workflows/deploy.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
